### PR TITLE
add hook that runs after successful invalidation

### DIFF
--- a/wp-graphcdn.php
+++ b/wp-graphcdn.php
@@ -441,7 +441,7 @@ add_action('shutdown', function () {
   /** Skip sending any request if there is nothing to purge. */
   if ($selection_set === '') return;
 
-  $query = "mutation WPGraphCDNIntegration(\$soft: Boolean {$variable_definitions}) {
+  $query = "mutation WPGraphCDNIntegration({$variable_definitions}) {
     {$selection_set}
   }";
   $err = call_admin_api($query, $variable_values);


### PR DESCRIPTION
This was also triggered by user feedback. There are cases where customer want to do more invalidation logic (e.g. ISR on Vercel) on top of invalidating GraphCDN caching. This PR adds an action hook `graphcdn_purge` that users can hook into:
- It's called after we successfully purged using the admin-api.
- We pass an array as argument that contains information about what we invalidated:
  - `has_purged_all`: A boolean that indicates if everything has been purged
  - `purged_types`: An array of typenames that have been purged completely
  - `<typename>`: An array with ids that have been purged for this type

I also fixed a duplicate variable definition in the mutation that lead to us always purging everything.