### PR TITLE
bump wordpress version

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Stellate ===
 Tags: Stellate, GraphQL, WPGraphQL, API, Caching, Edge, Performance
 Requires at least: 5.0
-Tested up to: 5.9.3
+Tested up to: 6.0.0
 Requires PHP: 7.1
 Stable tag: 0.1.1
 License: GPL-3

--- a/wp-stellate.php
+++ b/wp-stellate.php
@@ -9,7 +9,7 @@
  * Author URI: https://stellate.co
  * Version: 0.1.1
  * Requires at least: 5.0
- * Tested up to: 5.9.3
+ * Tested up to: 6.0.0
  * Requires PHP: 7.1
  * License: GPL-3
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
Though a major release, it seems that there are no real breaking changes on the technical side, so our plugin should continue to function without problems.