### PR TITLE
avoid accessing undefined array indices

### DIFF
--- a/wp-stellate.php
+++ b/wp-stellate.php
@@ -250,8 +250,8 @@ add_action('registered_taxonomy', function (string $taxonomy, $object_type, arra
  * pages and menu items.
  */
 add_action('wp_insert_post', function (int $post_id, WP_Post $post, bool $update) {
+  if (!array_key_exists($post->post_type, $GLOBALS['gcdn_typename_map'])) return;
   $type = $GLOBALS['gcdn_typename_map'][$post->post_type];
-  if (!$type) return;
 
   if ($update) {
     /**
@@ -285,8 +285,8 @@ add_action('wp_insert_post', function (int $post_id, WP_Post $post, bool $update
  * items.
  */
 add_action('deleted_post', function (int $post_id, WP_Post $post) {
+  if (!array_key_exists($post->post_type, $GLOBALS['gcdn_typename_map'])) return;
   $type = $GLOBALS['gcdn_typename_map'][$post->post_type];
-  if (!$type) return;
   stellate_add_purge_entity($type, $post_id);
 }, 10, 2);
 


### PR DESCRIPTION
Resolves [GCDN-1975](https://linear.app/stellate/issue/GCDN-1975/stellate-wordpress-plugin-crashes-wordpress-on-post-preview)

TIL that PHP complains when you try to access an array index that does not exist. Not sure if this fixes the issue of the customer, but this is my best guess 🤷 (can't really reproduce it)