### PR TITLE
bump plugin and WordPress version

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === Stellate ===
 Tags: Stellate, GraphQL, WPGraphQL, API, Caching, Edge, Performance
 Requires at least: 5.0
-Tested up to: 6.0.0
+Tested up to: 6.1.0
 Requires PHP: 7.1
-Stable tag: 0.1.1
+Stable tag: 0.1.2
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/wp-stellate.php
+++ b/wp-stellate.php
@@ -7,16 +7,16 @@
  * Description: Stellate for your WordPress GraphQL API
  * Author: Stellate
  * Author URI: https://stellate.co
- * Version: 0.1.1
+ * Version: 0.1.2
  * Requires at least: 5.0
- * Tested up to: 6.0.0
+ * Tested up to: 6.1.0
  * Requires PHP: 7.1
  * License: GPL-3
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  *
  * @package  Stellate
  * @author   Stellate
- * @version  0.1.1
+ * @version  0.1.2
  */
 
 /**


### PR DESCRIPTION
For reference, here's the changes for WordPress 6.1: https://make.wordpress.org/core/2022/10/12/wordpress-6-1-field-guide/