### PR TITLE
make sure to capitalize type names

### DIFF
--- a/wp-stellate.php
+++ b/wp-stellate.php
@@ -437,7 +437,7 @@ add_action('shutdown', function () {
           $uppercase_key = ucfirst($key);
           $variable_name = "\${$key}Ids";
           $variable_definitions .= " {$variable_name}: [ID!]";
-          $selection_set .= "purge{$key}ById: purge{$uppercase_key}(soft: \$soft, id: {$variable_name})\n";
+          $selection_set .= "purge{$uppercase_key}ById: purge{$uppercase_key}(soft: \$soft, id: {$variable_name})\n";
           $variable_values[$variable_name] = stellate_encode_ids($value, $GLOBALS['gcdn_id_prefix_map'][$key]);
         }
         break;


### PR DESCRIPTION
Instead of going with the approach that our dear user suggested, I left the array keys untouched (i.e. not necessarily capitalized) and only capitalized the type name when building the query we send of to the admin api. That way this logic is only happening in one place and you can't easily mess up other logic by forgetting to capitalize in a certain spot.