### PR TITLE
Skip purges for autosaves, revisions, and auto-drafts

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Tags: Stellate, GraphQL, WPGraphQL, API, Caching, Edge, Performance
 Requires at least: 5.0
 Tested up to: 6.4.0
 Requires PHP: 7.1
-Stable tag: 0.1.8
+Stable tag: 0.1.9
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/wp-stellate.php
+++ b/wp-stellate.php
@@ -267,6 +267,14 @@ add_action('registered_taxonomy', function (string $taxonomy, $object_type, arra
  * pages and menu items.
  */
 add_action('wp_insert_post', function (int $post_id, WP_Post $post, bool $update) {
+  // Skip events that don't change anything user-facing:
+  // - autosaves fire every few seconds in Gutenberg
+  // - revisions are tracked by WordPress core (and some plugins like ACF)
+  // - auto-draft / inherit / new are intermediate statuses with no public content
+  if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) return;
+  if (wp_is_post_revision($post_id) || wp_is_post_autosave($post_id)) return;
+  if (in_array($post->post_status, ['auto-draft', 'inherit', 'new'], true)) return;
+
   if (!array_key_exists($post->post_type, $GLOBALS['gcdn_typename_map'])) return;
   $type = $GLOBALS['gcdn_typename_map'][$post->post_type];
 

--- a/wp-stellate.php
+++ b/wp-stellate.php
@@ -7,7 +7,7 @@
  * Description: Stellate for your WordPress GraphQL API
  * Author: Stellate
  * Author URI: https://stellate.co
- * Version: 0.1.8
+ * Version: 0.1.9
  * Requires at least: 5.0
  * Tested up to: 6.4.0
  * Requires PHP: 7.1
@@ -16,7 +16,7 @@
  *
  * @package  Stellate
  * @author   Stellate
- * @version  0.1.8
+ * @version  0.1.9
  */
 
 /**


### PR DESCRIPTION
Adds three early-exit guards to the `wp_insert_post` handler so we don't purge on events that have no public-facing impact:

- `DOING_AUTOSAVE` — Gutenberg autosaves
- `wp_is_post_revision` / `wp_is_post_autosave` — revision rows
- `auto-draft` / `inherit` / `new` statuses — fired just by opening "Add New Post"

No behavior change for any publicly-visible event. Eliminates the most common source of phantom purges on editorial sites.

 | Before | After |
| --------|-----|
| ![](https://github.com/user-attachments/assets/8fea94f1-e7b7-4c90-a5e5-278ba1244c83) |  ![](https://github.com/user-attachments/assets/60262f9e-d9c4-4cdd-8b8f-fc766dae1dbc) | 