### PR TITLE
Fix PHP 8.2 ${var} string interpolation deprecation

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Tags: Stellate, GraphQL, WPGraphQL, API, Caching, Edge, Performance
 Requires at least: 5.0
 Tested up to: 6.4.0
 Requires PHP: 7.1
-Stable tag: 0.1.9
+Stable tag: 0.1.10
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/wp-stellate.php
+++ b/wp-stellate.php
@@ -7,7 +7,7 @@
  * Description: Stellate for your WordPress GraphQL API
  * Author: Stellate
  * Author URI: https://stellate.co
- * Version: 0.1.9
+ * Version: 0.1.10
  * Requires at least: 5.0
  * Tested up to: 6.4.0
  * Requires PHP: 7.1
@@ -16,7 +16,7 @@
  *
  * @package  Stellate
  * @author   Stellate
- * @version  0.1.9
+ * @version  0.1.10
  */
 
 /**

--- a/wp-stellate.php
+++ b/wp-stellate.php
@@ -257,7 +257,7 @@ add_action('registered_taxonomy', function (string $taxonomy, $object_type, arra
   /**
    * This runs when deleting a term.
    */
-  add_action("delete_${taxonomy}", function (int $term_id) use ($args) {
+  add_action("delete_{$taxonomy}", function (int $term_id) use ($args) {
     stellate_add_purge_entity($args['graphql_single_name'], $term_id);
   });
 }, 10, 3);


### PR DESCRIPTION
Replaces the deprecated `${var}` syntax with `{\$var}` at [wp-stellate.php:260](../blob/main/wp-stellate.php#L260).

The `${var}` form inside double-quoted strings was deprecated in PHP 8.2 and will be a fatal error in PHP 9. The sibling `created_{\$taxonomy}` and `edited_{\$taxonomy}` hooks just above use the modern syntax — this just brings the last holdout in line.

Visible in dev logs as:

```
PHP Deprecated:  Using ${var} in strings is deprecated, use {\$var} instead in wp-stellate.php on line 260
```

One character change, no behavior difference.

|Before  | After |
| -------|------|
| <img width="2880" height="216" alt="CleanShot 2026-06-04 at 16 56 33@2x" src="https://github.com/user-attachments/assets/20e2fb5a-590e-4cda-a7bd-a0433d49e29a" /> | <img width="2834" height="154" alt="CleanShot 2026-06-04 at 16 57 52@2x" src="https://github.com/user-attachments/assets/13d95ba9-5214-4c81-b807-c3de2ec5293d" /> | 